### PR TITLE
feat: skip schema validation for content-types. feat: allocate buf with content-length

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Cellotape - Beta - OpenAPI Router for Go
 
-![98.7%](https://badgen.net/badge/coverage/98.7%25/green?icon=github)
+![98.6%](https://badgen.net/badge/coverage/98.6%25/green?icon=github)
 
 Cellotape requires Go 1.18 or above.
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/invopop/jsonschema v0.4.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/options-schema.json
+++ b/options-schema.json
@@ -26,6 +26,12 @@
         "handleAllOperationResponses": {
           "type": "integer"
         },
+        "runtimeValidateRequestContentTypeToIgnore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "runtimeValidateResponses": {
           "type": "integer"
         }

--- a/options-schema.json
+++ b/options-schema.json
@@ -26,7 +26,7 @@
         "handleAllOperationResponses": {
           "type": "integer"
         },
-        "runtimeValidateRequestContentTypeToIgnore": {
+        "contentTypesToSkipRuntimeValidation": {
           "items": {
             "type": "string"
           },

--- a/router/binders_test.go
+++ b/router/binders_test.go
@@ -92,7 +92,7 @@ func TestPathBinderFactoryError(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactory(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(withBody("42")), &param)
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestRequestBodyBinderFactoryWithSchema(t *testing.T) {
 	testOp.RequestBody = &openapi3.RequestBodyRef{
 		Value: openapi3.NewRequestBody().WithJSONSchema(openapi3.NewIntegerSchema()),
 	}
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(
 		withBody("42"),
@@ -115,7 +115,7 @@ func TestRequestBodyBinderFactoryWithSchema(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactoryError(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 
 	err := requestBodyBinder(testContext(withBody(`"foo"`)), &param)
@@ -131,7 +131,7 @@ func (r readerWithError) Read(_ []byte) (int, error) {
 }
 
 func TestRequestBodyBinderFactoryReaderError(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(
 		withBodyReader(io.NopCloser(readerWithError(`42`)))), &param)
@@ -139,7 +139,7 @@ func TestRequestBodyBinderFactoryReaderError(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactoryContentTypeError(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 
 	err := requestBodyBinder(testContext(
@@ -149,7 +149,7 @@ func TestRequestBodyBinderFactoryContentTypeError(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactoryContentTypeWithCharset(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(
 		withBody("42"),
@@ -159,7 +159,7 @@ func TestRequestBodyBinderFactoryContentTypeWithCharset(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactoryInvalidContentType(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(
 		withBody("42"),
@@ -168,7 +168,7 @@ func TestRequestBodyBinderFactoryInvalidContentType(t *testing.T) {
 }
 
 func TestRequestBodyBinderFactoryContentTypeAnyWithCharset(t *testing.T) {
-	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes())
+	requestBodyBinder := requestBodyBinderFactory[int](reflect.TypeOf(0), DefaultContentTypes(), DefaultOptions())
 	var param int
 	err := requestBodyBinder(testContext(
 		withBody("42"),

--- a/router/options.go
+++ b/router/options.go
@@ -151,7 +151,8 @@ type OperationValidationOptions struct {
 	// HandleAllOperationResponses describes the behaviour when not every response defined in the spec is handled at least once in the handlers chain
 	HandleAllOperationResponses Behaviour `json:"handleAllOperationResponses,omitempty"`
 
-	RuntimeValidateRequestContentTypeToIgnore []string `json:"runtimeValidateRequestContentTypeToIgnore,omitempty"`
+	// ContentTypesToSkipRuntimeValidation defines a list of content types that are skipped when validating operation request body at runtime.
+	ContentTypesToSkipRuntimeValidation []string `json:"contentTypesToSkipRuntimeValidation,omitempty"`
 
 	// RuntimeValidateResponses defines the behaviour when validating operation response body at runtime. Printing a warning to
 	// the log by default. It is recommended to turn this option to Ignore in production as it can impact performance for large
@@ -178,13 +179,13 @@ func DefaultOptions() Options {
 		LogLevel:       LogLevelInfo,
 		LogOutput:      os.Stderr,
 		DefaultOperationValidation: OperationValidationOptions{
-			ValidateRequestBody:                       PropagateError,
-			ValidatePathParams:                        PropagateError,
-			ValidateQueryParams:                       PropagateError,
-			ValidateResponses:                         PropagateError,
-			HandleAllOperationResponses:               PropagateError,
-			RuntimeValidateRequestContentTypeToIgnore: []string{PlainTextContentType{}.Mime(), OctetStreamContentType{}.Mime()},
-			RuntimeValidateResponses:                  PrintWarning,
+			ValidateRequestBody:                 PropagateError,
+			ValidatePathParams:                  PropagateError,
+			ValidateQueryParams:                 PropagateError,
+			ValidateResponses:                   PropagateError,
+			HandleAllOperationResponses:         PropagateError,
+			ContentTypesToSkipRuntimeValidation: []string{PlainTextContentType{}.Mime(), OctetStreamContentType{}.Mime()},
+			RuntimeValidateResponses:            PrintWarning,
 		},
 		MustHandleAllOperations: PropagateError,
 		HandleAllContentTypes:   PropagateError,

--- a/router/options.go
+++ b/router/options.go
@@ -151,6 +151,8 @@ type OperationValidationOptions struct {
 	// HandleAllOperationResponses describes the behaviour when not every response defined in the spec is handled at least once in the handlers chain
 	HandleAllOperationResponses Behaviour `json:"handleAllOperationResponses,omitempty"`
 
+	RuntimeValidateRequestContentTypeToIgnore []string `json:"runtimeValidateRequestContentTypeToIgnore,omitempty"`
+
 	// RuntimeValidateResponses defines the behaviour when validating operation response body at runtime. Printing a warning to
 	// the log by default. It is recommended to turn this option to Ignore in production as it can impact performance for large
 	// responses, and to be used in development and testing environments.
@@ -176,12 +178,13 @@ func DefaultOptions() Options {
 		LogLevel:       LogLevelInfo,
 		LogOutput:      os.Stderr,
 		DefaultOperationValidation: OperationValidationOptions{
-			ValidateRequestBody:         PropagateError,
-			ValidatePathParams:          PropagateError,
-			ValidateQueryParams:         PropagateError,
-			ValidateResponses:           PropagateError,
-			HandleAllOperationResponses: PropagateError,
-			RuntimeValidateResponses:    PrintWarning,
+			ValidateRequestBody:                       PropagateError,
+			ValidatePathParams:                        PropagateError,
+			ValidateQueryParams:                       PropagateError,
+			ValidateResponses:                         PropagateError,
+			HandleAllOperationResponses:               PropagateError,
+			RuntimeValidateRequestContentTypeToIgnore: []string{PlainTextContentType{}.Mime(), OctetStreamContentType{}.Mime()},
+			RuntimeValidateResponses:                  PrintWarning,
 		},
 		MustHandleAllOperations: PropagateError,
 		HandleAllContentTypes:   PropagateError,


### PR DESCRIPTION
# Changes
1. Enable default options (configuration) for skipping body validations for some content-types. By default it's "application/octet-stream" and "plain/text". By NOT validating those, we save up some precious time per request. Can be overridden by the user.
2. Pre-allocate a buffer for the request body before passing to the handler, if `Content-Type` header is present and positive. This prevents io.ReadAll from allocation and reallocating for large buffers.