### PR TITLE
feat: better response validation err

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Cellotape - Beta - OpenAPI Router for Go
 
-![98.7%](https://badgen.net/badge/coverage/98.7%25/green?icon=github)
+![](https://badgen.net/badge/coverage/25/green?icon=github)
 
 Cellotape requires Go 1.18 or above.
 

--- a/router/binders.go
+++ b/router/binders.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -341,7 +342,8 @@ func validationOptions() *openapi3filter.Options {
 	options := openapi3filter.Options{}
 	// Customize the error message returned by the kin-openapi library to be more user-friendly.
 	options.WithCustomSchemaErrorFunc(func(err *openapi3.SchemaError) string {
-		return err.Reason
+		p := err.JSONPointer()
+		return fmt.Sprintf("Error at \"%s\": %s", "/"+strings.Join(p, "/"), err.Reason)
 	})
 	return &options
 }


### PR DESCRIPTION
Before:
```
2024/10/03 12:48:53 [WARNING] response body doesn't match schema #/components/schemas/Config: value must be an integer. response violates the spec
```

After:
```
2024/10/03 12:46:43 [WARNING] response body doesn't match schema #/components/schemas/Config: Error at "/db/gc/retention_period": value must be an integer. response violates the spec
```